### PR TITLE
Ensure datapackage<1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask>=0.11.1
 flask_cache>=0.13.1
 lxml
-datapackage>=0.8.4
+datapackage>=0.8.4,<1.0
 babel>=2.3.4


### PR DESCRIPTION
Hi! Frictionless Data's `datapackage-py` is going to reach v1 release and it could be breaking for some software (we use SemVer). Adding `<1.0` version requirement.